### PR TITLE
Remove trailing slash from base URL variable

### DIFF
--- a/MultiSafePay - API .postman_collection.json
+++ b/MultiSafePay - API .postman_collection.json
@@ -1262,7 +1262,7 @@
 		{
 			"id": "8d57572e-8924-4125-b091-0c381db4e9bd",
 			"key": "baseUrl",
-			"value": "https://testapi.multisafepay.com/v1/json/",
+			"value": "https://testapi.multisafepay.com/v1/json",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
By default, any request to the MultiSafePay Test API always yields the following error response:
```json
{
    "success": false,
    "data": {},
    "error_code": 1000,
    "error_info": "Invalid request received"
}
```
This happens because the default value of the `baseUrl` variable has a trailing slash, causing a double slash to appear in each request. 

For example, a request to `{baseUrl}/categories` would by substitution be sent as `https://testapi.multisafepay.com/v1/json//categories` rather than `https://testapi.multisafepay.com/v1/json/categories`. Removing this trailing slash from the default variables fixes this issue.